### PR TITLE
Ubuntu 16 Fix + Pruning Offset for Block Re-org Protection

### DIFF
--- a/sqlchain/blkdat.py
+++ b/sqlchain/blkdat.py
@@ -137,8 +137,14 @@ def initdb(cfg):
     cur.execute("select count(1) from information_schema.tables where table_name='blkdat';")
     if not cur.fetchone()[0]:
         cur.execute(sqlmk) # create table if not existing
-    cur.execute("select filenum,max(filepos) from blkdat where filenum=(select max(filenum) from blkdat);") # find any previous position
-    row = cur.fetchone()
+    
+    #queries separated for ubuntu 16 compatibility.
+    cur.execute("select max(filenum) from blkdat;") # find any previous position
+    maxFileNum = cur.fetchone()[0]
+    cur.execute("select max(filepos) from blkdat where filenum=%s;", (maxFileNum,) )
+    maxFilePos = cur.fetchone()[0]
+    row = (maxFileNum, maxFilePos)
+
     if row != (None,None):
         lastpos = row
         cur.execute("""select (select min(t3.id)-1 from blkdat t3 where t3.id > t1.id) as blk,

--- a/sqlchaind
+++ b/sqlchaind
@@ -105,7 +105,7 @@ def chkPruning(blk):
     if blk > 120000 and blk % 100 == 0:
         blkinfo = sqc.rpc.getblockchaininfo()
         if blkinfo['pruned']:
-            sqc.rpc.pruneblockchain(blk)
+            sqc.rpc.pruneblockchain(blk-20) #keep a 20 block offset in case of a reorg, we will need this history
         maxblk = blkinfo['headers']
     
 def BlockHandler():


### PR DESCRIPTION
Hey,

- I installed on Ubuntu 16, and the MySQL version was throwing this error for the blkdat.py line 140 query: Error: "In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'bitcoin.blkdat.filenum'; this is incompatible with sql_mode=only_full_group_by"
I fixed it by just simply separating the queries to make MySQL happy.

- I worry that the current pruning could delete blocks that may be needed by the checkReOrg() function during block re-orgs. I've added a 20 block offset safety factor.

Glad to see you back, thank you